### PR TITLE
First cut at sign_core

### DIFF
--- a/aws-sigv4/src/lib.rs
+++ b/aws-sigv4/src/lib.rs
@@ -16,7 +16,7 @@ type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 use http::header::HeaderName;
 use sign::{calculate_signature, encode_with_hex, generate_signing_key};
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::time::SystemTime;
 use types::{AsSigV4, CanonicalRequest, DateTimeExt, StringToSign};
 
 pub fn sign<B>(
@@ -28,9 +28,7 @@ pub fn sign<B>(
 where
     B: AsRef<[u8]>,
 {
-    for (header_name, header_value) in
-        sign_core(&req, req.body(), credential, region, svc, SystemTime::now())
-    {
+    for (header_name, header_value) in sign_core(&req, credential, region, svc, SystemTime::now()) {
         req.headers_mut()
             .append(header_name.header_name(), header_value.parse()?);
     }
@@ -60,14 +58,16 @@ impl SignatureKey {
 
 pub fn sign_core<B>(
     req: &http::Request<B>,
-    payload: impl AsRef<[u8]>,
     credential: &Credentials,
     region: &str,
     svc: &str,
     date: SystemTime,
-) -> Vec<(SignatureKey, String)> {
+) -> Vec<(SignatureKey, String)>
+where
+    B: AsRef<[u8]>,
+{
     // Step 1: https://docs.aws.amazon.com/en_pv/general/latest/gr/sigv4-create-canonical-request.html.
-    let creq = CanonicalRequest::from_req_payload(req, payload).unwrap();
+    let creq = CanonicalRequest::from(req).unwrap();
 
     // Step 2: https://docs.aws.amazon.com/en_pv/general/latest/gr/sigv4-create-string-to-sign.html.
     let encoded_creq = &encode_with_hex(creq.fmt());

--- a/aws-sigv4/src/lib.rs
+++ b/aws-sigv4/src/lib.rs
@@ -38,7 +38,7 @@ where
     Ok(())
 }
 
-/// SignatureKey is the key half of the key-value pair of a generated signature
+/// SignatureKey is the key portion of the key-value pair of a generated SigV4 signature.
 ///
 /// When signing with SigV4, the algorithm produces multiple components of a signature that MUST
 /// be applied to a request.

--- a/aws-sigv4/src/lib.rs
+++ b/aws-sigv4/src/lib.rs
@@ -16,8 +16,8 @@ type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 use http::header::HeaderName;
 use sign::{calculate_signature, encode_with_hex, generate_signing_key};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use types::{AsSigV4, CanonicalRequest, DateTimeExt, StringToSign};
-use std::time::{Instant, UNIX_EPOCH, SystemTime};
 
 pub fn sign<B>(
     req: &mut http::Request<B>,
@@ -25,10 +25,12 @@ pub fn sign<B>(
     region: &str,
     svc: &str,
 ) -> Result<(), Error>
-    where
-        B: AsRef<[u8]>,
+where
+    B: AsRef<[u8]>,
 {
-    for (header_name, header_value) in sign_core(&req, req.body(), credential, region, svc, SystemTime::now()) {
+    for (header_name, header_value) in
+        sign_core(&req, req.body(), credential, region, svc, SystemTime::now())
+    {
         req.headers_mut()
             .append(header_name.header_name(), header_value.parse()?);
     }

--- a/aws-sigv4/src/types.rs
+++ b/aws-sigv4/src/types.rs
@@ -24,9 +24,10 @@ pub(crate) struct CanonicalRequest {
 }
 
 impl CanonicalRequest {
-    pub(crate) fn from<B>(
-        req: &Request<B>,
-    )  -> Result<CanonicalRequest, Error> where B: AsRef<[u8]> {
+    pub(crate) fn from<B>(req: &Request<B>) -> Result<CanonicalRequest, Error>
+    where
+        B: AsRef<[u8]>,
+    {
         let mut creq = CanonicalRequest {
             method: req.method().clone(),
             path: req.uri().path().to_string(),

--- a/aws-sigv4/src/types.rs
+++ b/aws-sigv4/src/types.rs
@@ -24,16 +24,9 @@ pub(crate) struct CanonicalRequest {
 }
 
 impl CanonicalRequest {
-    pub(crate) fn from<B>(req: &Request<B>) -> Result<CanonicalRequest, Error>
-    where
-        B: AsRef<[u8]>,
-    {
-        Self::from_req_payload(req, req.body())
-    }
-    pub(crate) fn from_req_payload<B>(
+    pub(crate) fn from<B>(
         req: &Request<B>,
-        payload: impl AsRef<[u8]>,
-    ) -> Result<CanonicalRequest, Error> {
+    )  -> Result<CanonicalRequest, Error> where B: AsRef<[u8]> {
         let mut creq = CanonicalRequest {
             method: req.method().clone(),
             path: req.uri().path().to_string(),
@@ -51,7 +44,7 @@ impl CanonicalRequest {
         }
         creq.signed_headers = SignedHeaders { inner: headers };
         creq.headers = req.headers().clone();
-        let body: &[u8] = payload.as_ref();
+        let body: &[u8] = req.body().as_ref();
         let payload_hash = encode_bytes_with_hex(body);
         creq.payload_hash = payload_hash;
         Ok(creq)

--- a/aws-sigv4/src/types.rs
+++ b/aws-sigv4/src/types.rs
@@ -24,7 +24,7 @@ pub(crate) struct CanonicalRequest {
 }
 
 impl CanonicalRequest {
-    pub(crate) fn from<B>(req: &mut Request<B>) -> Result<CanonicalRequest, Error>
+    pub(crate) fn from<B>(req: &Request<B>) -> Result<CanonicalRequest, Error>
     where
         B: AsRef<[u8]>,
     {

--- a/aws-sigv4/src/types.rs
+++ b/aws-sigv4/src/types.rs
@@ -28,6 +28,12 @@ impl CanonicalRequest {
     where
         B: AsRef<[u8]>,
     {
+        Self::from_req_payload(req, req.body())
+    }
+    pub(crate) fn from_req_payload<B>(
+        req: &Request<B>,
+        payload: impl AsRef<[u8]>,
+    ) -> Result<CanonicalRequest, Error> {
         let mut creq = CanonicalRequest {
             method: req.method().clone(),
             path: req.uri().path().to_string(),
@@ -45,9 +51,9 @@ impl CanonicalRequest {
         }
         creq.signed_headers = SignedHeaders { inner: headers };
         creq.headers = req.headers().clone();
-        let body: &[u8] = req.body().as_ref();
-        let payload = encode_bytes_with_hex(body);
-        creq.payload_hash = payload;
+        let body: &[u8] = payload.as_ref();
+        let payload_hash = encode_bytes_with_hex(body);
+        creq.payload_hash = payload_hash;
         Ok(creq)
     }
 }

--- a/aws-sigv4/src/types.rs
+++ b/aws-sigv4/src/types.rs
@@ -46,8 +46,8 @@ impl CanonicalRequest {
         creq.signed_headers = SignedHeaders { inner: headers };
         creq.headers = req.headers().clone();
         let body: &[u8] = req.body().as_ref();
-        let payload_hash = encode_bytes_with_hex(body);
-        creq.payload_hash = payload_hash;
+        let payload = encode_bytes_with_hex(body);
+        creq.payload_hash = payload;
         Ok(creq)
     }
 }


### PR DESCRIPTION
To enable signing a bit more flexibly:

1. Return the required changes to the request instead of mutating it
2. Allow an explicit time to be passed.

I don't love the name, open to suggestions.

I think _maybe_ we make CanonicalRequest public? And actually just take a canonical request as a parameter instead, but I'm still working on that.